### PR TITLE
新增手動同步遺漏資料功能

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "餅餅踏踏",
     "slug": "餅餅踏踏",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "myapp",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "stepstep",
       "version": "1.0.0",
       "dependencies": {
+        "@babel/runtime": "^7.24.5",
         "@expo/vector-icons": "^14.0.0",
         "@react-native-async-storage/async-storage": "1.23.1",
         "@react-navigation/native": "^6.0.2",


### PR DESCRIPTION
手動同步增加三天與最近一次自動同步起算至目前天數的的選項（最長仍同步 7 天內的資料），以解決 #3 的功能新增建議。

該功能只會在距離上次自動同步時間超過一天的情況下才會啟用，當點選這個按鈕時，將會自動計算尚未同步天數並上傳資料，也同時會再觸發背景自動同步服務。

<details>
  <summary>其他細節微調</summary>
  
- 自動同步頻率從每小時改為每三小時
- 上次自動同步時間的儲存為配合新功能計算，改以 ISOString 儲存原始時間，顯示時再該以 localeString 呈現
</details>


本次測試裝置資訊
- 型號：Pixel 4a 4G
- 系統版本：Android 13
- 備註：開啟電源管理無限制選項、開啟通知權限、允許顯示在應用程式上層

![image](https://github.com/user-attachments/assets/e0e5685e-ddbe-45eb-ae2b-ebdd1a0d765a)
